### PR TITLE
Update to 2.1.1

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-RIAK_VERSION      = "2.1.0"
+RIAK_VERSION      = "2.1.1"
 RIAK_DOWNLOAD_URL = "http://s3.amazonaws.com/downloads.basho.com/riak/2.1/#{RIAK_VERSION}/osx/10.8/riak-#{RIAK_VERSION}-OSX-x86_64.tar.gz"
 NUM_NODES = 5
 RING_SIZE = 16


### PR DESCRIPTION
Updated to 2.1.1 as 2.1.0 was pulled.

I ran through the standard test cycle that I use, as below, while tailing `riak1/log/console.log` & `riak3/log/error.log` for anything unexpected.

## test plan
- [X] `rake bootstrap`
- [X] `rake member_status` (wait for ring to converge)
- [X] `rake ping`
- [X] `rake test`
- [X] `rake map_bucket` *Note: There will be a warning on execution re. bucket-type setup*
- [X] `rake set_bucket`
- [X] `rake counter_bucket`
- [X] validate [HTTP API endpoint](http://127.0.0.1:11098) & [Riak Console](http://127.0.0.1:11098/admin) URL in a browser
- [X] `rake stop`
- [X] `ps -ef | grep riak` (to ensure everything stopped)
- [X] `rake start`
- [X] `rake member_status` (wait for ring to converge)
- [X] `rake test`
- [X] validate [HTTP API endpoint](http://127.0.0.1:11098) & [Riak Console](http://127.0.0.1:11098/admin) URL in a browser
- [X] `rake restart`
- [X] `rake member_status` (wait for ring to converge)
- [X] `rake test`
- [X] `curl -XPUT http://riak1@127.0.01:11098/buckets/test/keys/console -H 'Content-type: text/plain' -d 'testing 1,2,3'`
- [X] `curl http://riak3@127.0.0.1:13098/buckets/test/keys/console`
- [X] `rake clear`
- [X] `rm -rf riak-2*/`
- [X] `rake install`
- [X] `rake start`
- [X] `rake join`
- [X] `rake member_status` (wait for ring to converge)
- [X] `rake test`
- [X] `rake clear` 
